### PR TITLE
feat: server-side auto decay system

### DIFF
--- a/class/PlayerStatus.lua
+++ b/class/PlayerStatus.lua
@@ -14,7 +14,7 @@ local Status = require("class.Status")
 local DEBUG  = require("shared.config").debug
 
 ---@param name string
----@param value number
+---@param value number | string | boolean
 ---@return boolean
 function PlayerStatus:registerStatus(name, value)
     if self.statuses[name] then
@@ -63,7 +63,7 @@ function PlayerStatus:unregisterAllStatus()
 end
 
 ---@param name string
----@return number?
+---@return number | string | boolean | nil
 function PlayerStatus:getStatus(name)
     local status = self.statuses[name]
 
@@ -78,7 +78,7 @@ function PlayerStatus:getStatus(name)
     return status and status:getValue()
 end
 
----@return table<string, number>
+---@return table<string, number | string | boolean>
 function PlayerStatus:getAllStatus()
     local statuses = {}
 
@@ -90,7 +90,7 @@ function PlayerStatus:getAllStatus()
 end
 
 ---@param name string
----@param value number
+---@param value number | string | boolean
 ---@return boolean
 function PlayerStatus:setStatus(name, value)
     local status = self.statuses[name]
@@ -113,18 +113,18 @@ function PlayerStatus:setStatus(name, value)
 end
 
 ---@param playerId number
----@param restoredStatuses table<string, number>
+---@param restoredStatuses table<string, number | string | boolean>
 ---@return PlayerStatus?
 return function(playerId, restoredStatuses)
     local typePlayerId = type(playerId)
     local typeRestoredStatuses = type(restoredStatuses)
 
     if typePlayerId ~= "number" then
-        return ESX.Trace(("Invalid playerId passed while creating an instance of PlayerStatus class! Received '%s', expected 'number'"):format(typePlayerId), "error", true)
+        return ESX.Trace(("Invalid playerId passed while creating an instance of PlayerStatus class! Expected 'number', Received '%s'"):format(typePlayerId), "error", true)
     end
 
     if typeRestoredStatuses ~= "table" then
-        return ESX.Trace(("Invalid restoredStatuses passed while creating an instance of PlayerStatus class! Received '%s', expected 'table'"):format(typeRestoredStatuses), "error", true)
+        return ESX.Trace(("Invalid restoredStatuses passed while creating an instance of PlayerStatus class! Expected 'table', Received '%s'"):format(typeRestoredStatuses), "error", true)
     end
 
     local self = setmetatable({

--- a/class/PlayerStatusRegistry.lua
+++ b/class/PlayerStatusRegistry.lua
@@ -1,6 +1,6 @@
 ---@class PlayerStatusRegistry
 ---@field count number
----@field registry table<string, PlayerStatus>
+---@field registry table<number, PlayerStatus>
 local PlayerStatusRegistry = {}
 PlayerStatusRegistry.__index = PlayerStatusRegistry
 
@@ -88,7 +88,7 @@ function PlayerStatusRegistry:getPlayer(playerId)
     return self.registry[playerId]
 end
 
----@return table<string, PlayerStatus>
+---@return table<number, PlayerStatus>
 function PlayerStatusRegistry:getAllPlayers()
     return self.registry
 end

--- a/class/Status.lua
+++ b/class/Status.lua
@@ -1,6 +1,6 @@
 ---@class Status
 ---@field name string
----@field value number
+---@field value number | string | boolean
 local Status = {}
 Status.__index = Status
 
@@ -25,13 +25,15 @@ end
 ---@param value number
 ---@return boolean
 function Status:setValue(value)
-    if type(value) ~= "number" then
-        ESX.Trace(("Status:setValue(%s) for %s error type!"):format(value, self.name), "error", true)
+    local typeValue = type(value)
+
+    if typeValue ~= "number" and typeValue ~= "string" and typeValue ~= "boolean" then
+        ESX.Trace(("Status:setValue(%s) for %s error type! Expected 'number' or 'string' or 'boolean', received '%s'"):format(value, self.name, typeValue), "error", true)
 
         return false
     end
 
-    if not utils.isValueValid(value) then
+    if not utils.isStatusValueValid(self.name, value) then
         if DEBUG then
             ESX.Trace(("Status:setValue(%s) for %s error value is not valid!"):format(value, self.name), "trace", true)
         end

--- a/class/Status.lua
+++ b/class/Status.lua
@@ -17,22 +17,14 @@ function Status:getName()
     return self.name
 end
 
----@return number
+---@return number | string | boolean
 function Status:getValue()
     return self.value
 end
 
----@param value number
+---@param value number | string | boolean
 ---@return boolean
 function Status:setValue(value)
-    local typeValue = type(value)
-
-    if typeValue ~= "number" and typeValue ~= "string" and typeValue ~= "boolean" then
-        ESX.Trace(("Status:setValue(%s) for %s error type! Expected 'number' or 'string' or 'boolean', received '%s'"):format(value, self.name, typeValue), "error", true)
-
-        return false
-    end
-
     if not utils.isStatusValueValid(self.name, value) then
         if DEBUG then
             ESX.Trace(("Status:setValue(%s) for %s error value is not valid!"):format(value, self.name), "trace", true)
@@ -47,18 +39,18 @@ function Status:setValue(value)
 end
 
 ---@param name string
----@param value number
+---@param value number | string | boolean
 ---@return Status?
 return function(name, value)
     local typeName = type(name)
     local typeValue = type(value)
 
     if typeName ~= "string" then
-        return ESX.Trace(("Invalid nam passed while creating an instance of Status class! Received '%s', expected 'string'"):format(typeName), "error", true)
+        return ESX.Trace(("Invalid name passed while creating an instance of Status class! Expected 'string', Received '%s'"):format(typeName), "error", true)
     end
 
-    if typeValue ~= "number" then
-        return ESX.Trace(("Invalid value passed while creating an instance of Status class! Received '%s', expected 'number'"):format(typeValue), "error", true)
+    if typeValue ~= "number" and typeValue ~= "string" and typeValue ~= "boolean" then
+        return ESX.Trace(("Invalid value passed while creating an instance of Status class! Expected 'number' or 'string' or 'boolean', Received '%s'"):format(typeValue), "error", true)
     end
 
     return setmetatable({

--- a/server/main.lua
+++ b/server/main.lua
@@ -158,7 +158,7 @@ end
 ---Generates an export to retrieve the specified player's status value
 ---@param playerId number
 ---@param status string
----@return number?
+---@return number | string | boolean | nil
 function utils.api.getPlayerStatus(playerId, status)
     local player = tracker:getPlayer(playerId)
 
@@ -167,7 +167,7 @@ end
 
 ---Generates an export to retrieve all of the specified player's status values
 ---@param playerId number
----@return table<string, number>?
+---@return table<string, number | string | boolean>?
 function utils.api.getAllPlayerStatus(playerId)
     local player = tracker:getPlayer(playerId)
 
@@ -177,12 +177,12 @@ end
 ---Generates an export to set the specified player's status value
 ---@param playerId number
 ---@param status string
----@param amount number
+---@param value number | string | boolean
 ---@return boolean?
-function utils.api.setPlayerStatus(playerId, status, amount)
+function utils.api.setPlayerStatus(playerId, status, value)
     local player = tracker:getPlayer(playerId)
 
-    return player and player:setStatus(status, amount)
+    return player and player:setStatus(status, value)
 end
 
 ---Generates an export to increase the specified player's status value

--- a/server/main.lua
+++ b/server/main.lua
@@ -12,10 +12,25 @@ end
 ----------------UNIT TESTS---------------
 -----------------------------------------
 
-local utils   = require("shared.utils")
-local config  = require("shared.config")
-local tracker = require("class.PlayerStatusRegistry")()
-local DEBUG   = config.debug
+local utils            = require("shared.utils")
+local config           = require("shared.config")
+local tracker          = require("class.PlayerStatusRegistry")()
+local DEBUG            = config.debug
+local intervalStatuses = {}
+
+AddStateBagChangeHandler("statuses", "global", function(_, _, value)
+    if not value then return end
+
+    ---@cast value table<string, StatusConfig>
+
+    config.statuses = value
+
+    for name, data in pairs(config.statuses) do
+        intervalStatuses[name] = type(data.update) == "number" and type(data.value) == "number" and data.update
+    end
+
+    ---@cast intervalStatuses table<string, number?>
+end)
 
 ---@param playerId number
 ---@param xPlayer table
@@ -74,12 +89,9 @@ AddEventHandler("onResourceStop", onResourceStop)
 AddEventHandler("onServerResourceStop", onResourceStop)
 
 ---Setup the status system for players that are already logged in (in case of resource restart)
-do
-    CreateThread(function()
-        GlobalState:set("statuses", config.statuses, true)
-    end)
 
-    Wait(1000) -- wait for global statebag to initializes
+CreateThread(function()
+    GlobalState:set("statuses", config.statuses, true)
 
     local xPlayers, count = ESX.GetExtendedPlayers()
 
@@ -88,7 +100,7 @@ do
 
         onPlayerLoaded(xPlayer.playerId, xPlayer)
     end
-end
+end)
 
 -----------------------------------------
 -----------------EXPORTS-----------------
@@ -96,29 +108,27 @@ end
 
 ---Generates an export to register a status in the system
 ---@param statusName string
----@param statusData table<string, any>
+---@param statusData StatusConfig
 ---@return boolean?
 function utils.api.registerGlobalStatus(statusName, statusData)
-    local registeredStatuses = GlobalState["statuses"]
-
-    if registeredStatuses[statusName] then
+    if config.statuses[statusName] then
         ESX.Trace(("exports:registerGlobalStatus(%s) error status already exist!"):format(statusName), "error", true)
 
         return false
     end
 
-    if type(statusName) ~= "string" or type(statusData) ~= "table" or type(statusData?.value) ~= "number" then
+    if type(statusName) ~= "string" or type(statusData) ~= "table" or type(statusData?.value) == "nil" then
         ESX.Trace(("exports:registerGlobalStatus(%s) error type!"):format(statusName), "error", true)
 
         return false
     end
 
-    registeredStatuses[statusName] = statusData
-    GlobalState:set("statuses", registeredStatuses)
+    config.statuses[statusName] = statusData
+    GlobalState:set("statuses", config.statuses, true)
 
     --Register the new status for already logged in players
-    for _, playerData in pairs(tracker:getAllPlayers()) do
-        playerData:registerStatus(statusName, statusData.value)
+    for _, player in pairs(tracker:getAllPlayers()) do
+        player:registerStatus(statusName, statusData.value)
     end
 
     if DEBUG then
@@ -132,20 +142,18 @@ end
 ---@param statusName string
 ---@return boolean?
 function utils.api.unregisterGlobalStatus(statusName)
-    local registeredStatuses = GlobalState["statuses"]
-
-    if not registeredStatuses[statusName] then
+    if not config.statuses[statusName] then
         ESX.Trace(("exports:unregisterGlobalStatus(%s) error status does not exist!"):format(statusName), "error", true)
 
         return false
     end
 
-    registeredStatuses[statusName] = nil
-    GlobalState:set("statuses", registeredStatuses)
+    config.statuses[statusName] = nil
+    GlobalState:set("statuses", config.statuses, true)
 
     --Unregister the status from already logged in players
-    for _, playerData in pairs(tracker:getAllPlayers()) do
-        playerData:unregisterStatus(statusName)
+    for _, player in pairs(tracker:getAllPlayers()) do
+        player:unregisterStatus(statusName)
     end
 
     if DEBUG then
@@ -222,12 +230,7 @@ CreateThread(function()
         Wait(config.updateInterval)
 
         local batchStart = 1
-        local validStatuses = {}
         local allPlayers, numOfPlayers = ESX.GetExtendedPlayers()
-
-        for name, data in pairs(GlobalState["statuses"]) do
-            validStatuses[name] = type(data.update) == "number" and data.update
-        end
 
         while batchStart <= numOfPlayers do
             local batchEnd = math.min(batchStart + BATCH_SIZE - 1, numOfPlayers)
@@ -243,7 +246,7 @@ CreateThread(function()
                 local playerStatuses = player:getAllStatus()
 
                 for statusName, statusValue in pairs(playerStatuses) do
-                    local updateAmount = validStatuses[statusName]
+                    local updateAmount = intervalStatuses[statusName]
 
                     if updateAmount then
                         if player:setStatus(statusName, statusValue + updateAmount) then

--- a/server/main.lua
+++ b/server/main.lua
@@ -204,3 +204,60 @@ end
 -----------------------------------------
 -----------------EXPORTS-----------------
 -----------------------------------------
+
+local statusDecayAmount = 0.2    -- Amount to decrease from each status
+local BATCH_SIZE = 32            -- Static batch size
+
+CreateThread(function()
+    while true do
+        Citizen.Wait(config.updateInterval)
+        
+        local batchStart = 1
+        local validStatuses = {}
+        local allPlayers = GetPlayers()
+        local numOfPlayers = #allPlayers
+        
+        for name, data in pairs(GlobalState["statuses"]) do
+            validStatuses[name] = type(value.update) and value.update
+        end
+
+        while batchStart <= numOfPlayers do
+            local batchEnd = math.min(batchStart + BATCH_SIZE - 1, numOfPlayers)
+            local statusesChanged = false
+
+            -- Process each player in the batch
+            for i = batchStart, batchEnd do
+                local playerId = allPlayers[i]
+                local player = tracker:getPlayer(playerId)
+
+                if not player then goto skipPlayer end
+                
+                local playerStatuses = player:getAllStatus()
+
+                -- Iterate through each player's statuses and apply decay
+                for statusName, statusValue in pairs(playerStatuses) do
+                    if validStatuses[statusName] then
+                        if player:setStatus(statusName, statusValue - validStatuses[statusName]) then
+                            statusesChanged = true
+                        end
+                    end   
+                end
+
+                --TODO reduce function calls by getting all framework players at once
+                if statusesChanged then
+                    local xPlayer = ESX.GetPlayerFromId(playerId)
+
+                    if xPlayer then
+                        xPlayer.setMetadata("statuses", player:getAllStatus())
+                    end
+                end
+
+                ::skipPlayer::
+            end
+
+            -- Move to the next batch and apply delay
+            batchStart = batchEnd + 1
+            Citizen.Wait(100)  -- Apply delay after each batch
+        end
+    end
+end)

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -1,8 +1,10 @@
 return {
     debug = false,
+    updateInterval = 30 * 1000
     statuses = {
         hunger = {
-            value = 50
+            value = 50,
+            update = 0.01
         }
     }
 }

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -1,10 +1,41 @@
 return {
-    debug = false,
-    updateInterval = 30 * 1000
+    debug = true,
+    updateInterval = 30 * 1000,
     statuses = {
         hunger = {
             value = 50,
+            update = -0.03
+        },
+        thirst = {
+            value = 50,
+            update = -0.04
+        },
+        stamina = {
+            value = 50,
+            update = -0.01
+        },
+        strength = {
+            value = 50,
+            update = -0.01
+        },
+        driving = {
+            value = 50,
+            update = -0.01
+        },
+        stress = {
+            value = 50,
+            update = -0.01
+        },
+        health = {
+            value = 50
+        },
+        energy = {
+            value = 50,
+            update = -0.01
+        },
+        sleep = {
+            value = 0,
             update = 0.01
-        }
+        },
     }
 }

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -1,3 +1,9 @@
+---@class StatusConfig
+---@field value number | string | boolean
+---@field min? number
+---@field max? number
+---@field update? number
+
 return {
     debug = true,
     updateInterval = 30 * 1000,

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -2,40 +2,40 @@ return {
     debug = true,
     updateInterval = 30 * 1000,
     statuses = {
-        hunger = {
-            value = 50,
-            update = -0.03
-        },
-        thirst = {
-            value = 50,
-            update = -0.04
-        },
-        stamina = {
-            value = 50,
-            update = -0.01
-        },
-        strength = {
-            value = 50,
-            update = -0.01
-        },
-        driving = {
-            value = 50,
-            update = -0.01
-        },
-        stress = {
-            value = 50,
-            update = -0.01
-        },
-        health = {
-            value = 50
-        },
-        energy = {
-            value = 50,
-            update = -0.01
-        },
-        sleep = {
-            value = 0,
-            update = 0.01
-        },
+        -- hunger = {
+        --     value = 50,
+        --     update = -0.03
+        -- },
+        -- thirst = {
+        --     value = 50,
+        --     update = -0.04
+        -- },
+        -- stamina = {
+        --     value = 50,
+        --     update = -0.01
+        -- },
+        -- strength = {
+        --     value = 50,
+        --     update = -0.01
+        -- },
+        -- driving = {
+        --     value = 50,
+        --     update = -0.01
+        -- },
+        -- stress = {
+        --     value = 50,
+        --     update = -0.01
+        -- },
+        -- health = {
+        --     value = 50
+        -- },
+        -- energy = {
+        --     value = 50,
+        --     update = -0.01
+        -- },
+        -- sleep = {
+        --     value = 0,
+        --     update = 0.01
+        -- },
     }
 }

--- a/shared/utils.lua
+++ b/shared/utils.lua
@@ -1,9 +1,43 @@
 local utils = {}
+local statuses = require("shared.config").statuses
+local toBoolean = {["false"] = false, ["true"] = true, [0] = false, [1] = true}
 
----@param amount number
+AddStateBagChangeHandler("statuses", "global", function(_, _, value)
+    statuses = value
+end)
+
+---@param value number | string
+---@return boolean?
+function utils.toBoolean(value)
+    local booleanValue = toBoolean[value]
+    return type(booleanValue) = "boolean" and booleanValue or nil
+end
+
+---@param status string
+---@param value number | string | boolean
 ---@return boolean
-function utils.isValueValid(amount)
-    return type(amount) == "number" and (amount >= 0 and amount <= 100)
+function utils.isStatusValueValid(name, value)
+    if not statuses[name] then return false end
+
+    local status = statuses[name]
+    local receivedType = type(value)
+    local expectedType = type(status)
+
+    if expectedType == "number" and receivedType == "number" then
+        if status.min and value < status.min then return false end
+        if status.max and value > status.max then return false end
+
+        return true
+    elseif expectedType == "string" and receivedType == "string" then
+        --TODO strict string value based on an declared enum in config?
+        return true
+    elseif expectedType == "boolean" and (receivedType == "boolean" or receivedType == "string" or receivedType == "number") then
+        local convertedValue = receivedType ~= "boolean" and utils.toBoolean(value) or value
+        
+        return type(convertedValue) ~= "nil" and convertedValue
+    end
+
+    return false
 end
 
 utils.api = setmetatable({}, {

--- a/shared/utils.lua
+++ b/shared/utils.lua
@@ -1,8 +1,12 @@
 local utils = {}
-local statuses = require("shared.config").statuses
+local statuses = require("shared.config").statuses --[[@as table<string, StatusConfig>]]
 local toBoolean = { ["false"] = false, ["true"] = true, [0] = false, [1] = true }
 
 AddStateBagChangeHandler("statuses", "global", function(_, _, value)
+    if not value then return end
+
+    ---@cast value table<string, StatusConfig>
+
     statuses = value
 end)
 

--- a/shared/utils.lua
+++ b/shared/utils.lua
@@ -1,6 +1,6 @@
 local utils = {}
 local statuses = require("shared.config").statuses
-local toBoolean = {["false"] = false, ["true"] = true, [0] = false, [1] = true}
+local toBoolean = { ["false"] = false, ["true"] = true, [0] = false, [1] = true }
 
 AddStateBagChangeHandler("statuses", "global", function(_, _, value)
     statuses = value
@@ -10,10 +10,10 @@ end)
 ---@return boolean?
 function utils.toBoolean(value)
     local booleanValue = toBoolean[value]
-    return type(booleanValue) = "boolean" and booleanValue or nil
+    return type(booleanValue) == "boolean" and booleanValue or nil
 end
 
----@param status string
+---@param name string
 ---@param value number | string | boolean
 ---@return boolean
 function utils.isStatusValueValid(name, value)
@@ -21,7 +21,7 @@ function utils.isStatusValueValid(name, value)
 
     local status = statuses[name]
     local receivedType = type(value)
-    local expectedType = type(status)
+    local expectedType = type(status.value)
 
     if expectedType == "number" and receivedType == "number" then
         if status.min and value < status.min then return false end
@@ -31,10 +31,12 @@ function utils.isStatusValueValid(name, value)
     elseif expectedType == "string" and receivedType == "string" then
         --TODO strict string value based on an declared enum in config?
         return true
-    elseif expectedType == "boolean" and (receivedType == "boolean" or receivedType == "string" or receivedType == "number") then
-        local convertedValue = receivedType ~= "boolean" and utils.toBoolean(value) or value
-        
-        return type(convertedValue) ~= "nil" and convertedValue
+    elseif expectedType == "boolean" then
+        if receivedType == "boolean" then
+            return true
+        elseif receivedType == "string" or receivedType == "number" then
+            return type(utils.toBoolean(value)) ~= "nil" and true
+        end
     end
 
     return false


### PR DESCRIPTION
* Statuses accept 3 types of values from now on (number, string and boolean)
* Statuses with numeric values can be set to update their amount on a _server-side interval_ automatically
* The static batch size of 32 on the server-side's auto decay thread loop should help manage a controlled, predictable load on the server, ensuring smooth performance even with a high player count. (**untested** on a large capacity server. _for robust optimal result we might need to increase wait time, reduce batch size, or even both?_)